### PR TITLE
Fix version in desktop file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,11 +71,6 @@ else()
     set(KTAILCTL_VERSION ${KTAILCTL_GIT_DESCRIBE})
 endif()
 message(STATUS "Version from git: ${KTAILCTL_VERSION}")
-configure_file(
-    org.fkoehler.KTailctl.desktop.in
-    ${CMAKE_CURRENT_BINARY_DIR}/org.fkoehler.KTailctl.desktop
-    @ONLY
-)
 configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/src/version.h @ONLY)
 
 install(

--- a/org.fkoehler.KTailctl.desktop
+++ b/org.fkoehler.KTailctl.desktop
@@ -3,11 +3,9 @@
 [Desktop Entry]
 Name=KTailctl
 Comment=GUI for tailscale on the KDE Plasma desktop
-Version=@KTAILCTL_VERSION@
+Version=1.5
 Exec=ktailctl
 Icon=org.fkoehler.KTailctl
 Type=Application
 Terminal=false
-# Add an actual main category here (and possibly applicable additional ones)
-#   https://specifications.freedesktop.org/menu-spec/latest/apa.html#main-category-registry
 Categories=Qt;KDE;System;


### PR DESCRIPTION
The version here shouldn't be the version of the app but is simply the version of the .desktop file standard used.

Fix `WARNING: Failed to validate desktop file /home/carl/kde/src/KTailctl/build-dir/export/share/applications/org.fkoehler.KTailctl.desktop: /home/carl/kde/src/KTailctl/build-dir/export/share/applications/org.fkoehler.KTailctl.desktop: error: value "v0.6.0-12-g550dbc8-dirty" for key "Version" in group "Desktop Entry" is not a known version`