### PR TITLE
Remove trailing dot in DNS names.

### DIFF
--- a/src/data/peer_data.cpp
+++ b/src/data/peer_data.cpp
@@ -36,6 +36,9 @@ void from_json(const json &j, PeerData &p)
         j.at("PublicKey").get_to<QString>(p.mPublicKey);
         j.at("HostName").get_to<QString>(p.mHostName);
         j.at("DNSName").get_to<QString>(p.mDnsName);
+        if (p.mDnsName.back() == QChar('.')) {
+            p.mDnsName.chop(1);
+        }
         j.at("OS").get_to<QString>(p.mOs);
         j.at("TailscaleIPs").get_to<QStringList>(p.mTailscaleIps);
         j.at("Relay").get_to<QString>(p.mRelay);


### PR DESCRIPTION
Fix #244 