### PR TITLE
Set exit node via DNS name.

### DIFF
--- a/src/components_plugin/PeerInfoPage.qml
+++ b/src/components_plugin/PeerInfoPage.qml
@@ -170,7 +170,7 @@ Kirigami.ScrollablePage {
                         if (root.peer.isCurrentExitNode)
                             Tailscale.unsetExitNode();
                         else
-                            Tailscale.setExitNode(peer.tailscaleIps[0]);
+                            Tailscale.setExitNode(peer.dnsName);
                     }
                 }
             }

--- a/src/tailscale/tailscale.cpp
+++ b/src/tailscale/tailscale.cpp
@@ -184,9 +184,9 @@ void Tailscale::refresh()
     emit refreshed();
 }
 
-void Tailscale::setExitNode(const QString &ip)
+void Tailscale::setExitNode(const QString &node)
 {
-    const QByteArray bytes = ip.toUtf8();
+    const QByteArray bytes = node.toUtf8();
     GoString tmp{bytes.data(), bytes.size()};
     tailscale_set_exit_node(&tmp);
 }

--- a/src/tailscale/tailscale.hpp
+++ b/src/tailscale/tailscale.hpp
@@ -81,7 +81,7 @@ public slots:
     Q_INVOKABLE void toggle();
     Q_INVOKABLE void refresh();
 
-    Q_INVOKABLE void setExitNode(const QString &ip);
+    Q_INVOKABLE void setExitNode(const QString &node);
     Q_INVOKABLE void unsetExitNode();
 };
 

--- a/src/tray_icon.cpp
+++ b/src/tray_icon.cpp
@@ -155,8 +155,8 @@ void TrayIcon::buildMullvadMenu()
         const QString countryCode = index.data(PeerModel::CountryCodeRole).toString().toLower();
         mMullvadCountryMenus[countryCode]->addAction(QIcon(QString(":/country-flags/country-flag-%1").arg(countryCode)),
                                                      index.data(PeerModel::DnsNameRole).toString(),
-                                                     [this, &index]() {
-                                                         mTailscale->setExitNode(index.data(PeerModel::TailscaleIpsRole).toStringList().front());
+                                                     [this, index]() {
+                                                         mTailscale->setExitNode(index.data(PeerModel::DnsNameRole).toString());
                                                      });
     }
 }
@@ -168,7 +168,7 @@ void TrayIcon::buildSelfHostedMenu()
     for (int i = 0; i < numNodes; ++i) {
         const QModelIndex index = mTailscale->exitNodeModel()->index(i, 0);
         mSelfHostedMenu->addAction(loadOsIcon(index.data(PeerModel::OsRole).toString()), index.data(PeerModel::DnsNameRole).toString(), [this, index]() {
-            mTailscale->setExitNode(index.data(PeerModel::TailscaleIpsRole).toStringList().front());
+            mTailscale->setExitNode(index.data(PeerModel::DnsNameRole).toString());
         });
     }
 }
@@ -209,7 +209,7 @@ void TrayIcon::buildPeerMenu()
             });
         } else if (peer.mIsExitNode) {
             submenu->addAction(QIcon::fromTheme(QStringLiteral("network-vpn")), QStringLiteral("Set as exit node"), [this, &peer]() {
-                mTailscale->setExitNode(peer.mTailscaleIps.front());
+                mTailscale->setExitNode(peer.mDnsName);
             });
         }
     }

--- a/src/ui/ExitNodes.qml
+++ b/src/ui/ExitNodes.qml
@@ -53,7 +53,7 @@ Kirigami.ScrollablePage {
                     visible: Tailscale.hasSuggestedExitNode
 
                     onClicked: {
-                        Tailscale.setExitNode(Tailscale.suggestedExitNode.tailscaleIps[0]);
+                        Tailscale.setExitNode(Tailscale.suggestedExitNode.dnsName);
                     }
                 }
             }
@@ -84,7 +84,7 @@ Kirigami.ScrollablePage {
                         text: dnsName
 
                         onClicked: {
-                            Tailscale.setExitNode(tailscaleIps[0]);
+                            Tailscale.setExitNode(dnsName);
                         }
                     }
                 }

--- a/src/ui/MullvadNodes.qml
+++ b/src/ui/MullvadNodes.qml
@@ -34,7 +34,7 @@ Kirigami.ScrollablePage {
                         text: dnsName + " (" + city + ")"
 
                         onClicked: {
-                            Tailscale.setExitNode(tailscaleIps[0]);
+                            Tailscale.setExitNode(dnsName);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #290, also makes the code for setting exit nodes simpler as Tailscale now allows specifying exit nodes by their DNS name.