### PR TITLE
Hide ExitNode actions

### DIFF
--- a/src/tray_icon.cpp
+++ b/src/tray_icon.cpp
@@ -122,6 +122,16 @@ TrayIcon::TrayIcon(QObject *parent)
 
 void TrayIcon::buildMullvadMenu()
 {
+    if (mTailscale->mullvadNodeModel()->rowCount() == 0) {
+        mMullvadMenu->setEnabled(false);
+        if (mTailscale->exitNodeModel()->rowCount() == 0) {
+            mExitNodeMenu->setEnabled(false);
+        }
+        return;
+    }
+    mMullvadMenu->setEnabled(true);
+    mExitNodeMenu->setEnabled(true);
+
     // check if rebuild is necessary
     const int newNumMullvadCountries = mTailscale->mullvadCountryModel()->rowCount({});
     const int newNumMullvadNodes = mTailscale->mullvadNodeModel()->rowCount({});
@@ -163,6 +173,16 @@ void TrayIcon::buildMullvadMenu()
 
 void TrayIcon::buildSelfHostedMenu()
 {
+    if (mTailscale->exitNodeModel()->rowCount() == 0) {
+        mSelfHostedMenu->setEnabled(false);
+        if (mTailscale->mullvadNodeModel()->rowCount() == 0) {
+            mExitNodeMenu->setEnabled(false);
+        }
+        return;
+    }
+    mSelfHostedMenu->setEnabled(true);
+    mExitNodeMenu->setEnabled(true);
+
     mSelfHostedMenu->clear();
     const int numNodes = mTailscale->exitNodeModel()->rowCount();
     for (int i = 0; i < numNodes; ++i) {

--- a/src/tray_icon.cpp
+++ b/src/tray_icon.cpp
@@ -29,7 +29,7 @@ TrayIcon::TrayIcon(QObject *parent)
     });
     mContextMenu->addSeparator();
     mPeerMenu = mContextMenu->addMenu(QIcon::fromTheme(QStringLiteral("applications-network")), QStringLiteral("Peers"));
-    mExitNodeMenu = mContextMenu->addMenu(QIcon::fromTheme(QStringLiteral("internet-services")), QStringLiteral("Exit Nodes"));
+    mExitNodeMenu = mContextMenu->addMenu(QIcon::fromTheme(QStringLiteral("internet-services")), QStringLiteral("Exit nodes"));
     mUnsetAction = mExitNodeMenu->addAction(QIcon::fromTheme(QStringLiteral("dialog-cancel")), QStringLiteral("Unset"), [this] {
         mTailscale->unsetExitNode();
     });
@@ -124,13 +124,13 @@ void TrayIcon::buildMullvadMenu()
 {
     if (mTailscale->mullvadNodeModel()->rowCount() == 0) {
         mMullvadMenu->setEnabled(false);
-        if (mTailscale->exitNodeModel()->rowCount() == 0) {
-            mExitNodeMenu->setEnabled(false);
-        }
+        mMullvadMenu->setTitle(QStringLiteral("No Mullvad"));
+        setExitNodeMenuEnabled(mTailscale->exitNodeModel()->rowCount() > 0);
         return;
     }
+    setExitNodeMenuEnabled(true);
     mMullvadMenu->setEnabled(true);
-    mExitNodeMenu->setEnabled(true);
+    mMullvadMenu->setTitle(QStringLiteral("Mullvad"));
 
     // check if rebuild is necessary
     const int newNumMullvadCountries = mTailscale->mullvadCountryModel()->rowCount({});
@@ -175,13 +175,13 @@ void TrayIcon::buildSelfHostedMenu()
 {
     if (mTailscale->exitNodeModel()->rowCount() == 0) {
         mSelfHostedMenu->setEnabled(false);
-        if (mTailscale->mullvadNodeModel()->rowCount() == 0) {
-            mExitNodeMenu->setEnabled(false);
-        }
+        mSelfHostedMenu->setTitle(QStringLiteral("No self-hosted"));
+        setExitNodeMenuEnabled(mTailscale->mullvadNodeModel()->rowCount() > 0);
         return;
     }
+    setExitNodeMenuEnabled(true);
+    mSelfHostedMenu->setTitle(QStringLiteral("Self-hosted"));
     mSelfHostedMenu->setEnabled(true);
-    mExitNodeMenu->setEnabled(true);
 
     mSelfHostedMenu->clear();
     const int numNodes = mTailscale->exitNodeModel()->rowCount();
@@ -273,4 +273,14 @@ void TrayIcon::setWindow(QQuickWindow *window)
 {
     mWindow = window;
     mOpenAction->setVisible(mWindow != nullptr);
+}
+
+void TrayIcon::setExitNodeMenuEnabled(bool enabled)
+{
+    mExitNodeMenu->setEnabled(enabled);
+    if (!enabled) {
+        mExitNodeMenu->setTitle(QStringLiteral("No exit nodes"));
+    } else {
+        mExitNodeMenu->setTitle(QStringLiteral("Exit nodes"));
+    }
 }

--- a/src/tray_icon.hpp
+++ b/src/tray_icon.hpp
@@ -49,6 +49,9 @@ public:
     virtual ~TrayIcon() = default;
 
     void setWindow(QQuickWindow *window);
+
+protected:
+    void setExitNodeMenuEnabled(bool enabled);
 };
 
 #endif /* KTAILCTL_TRAY_ICON_HPP */

--- a/src/ui/ExitNodes.qml
+++ b/src/ui/ExitNodes.qml
@@ -23,7 +23,15 @@ Kirigami.ScrollablePage {
         FormCard.FormHeader {
             Layout.fillWidth: true
             Layout.topMargin: Kirigami.Units.largeSpacing
+            title: i18nc("@title:group", "No exit nodes available!")
+            visible: (Tailscale.exitNodeModel.rowCount() == 0) && (Tailscale.mullvadNodeModel.rowCount() == 0)
+        }
+
+        FormCard.FormHeader {
+            Layout.fillWidth: true
+            Layout.topMargin: Kirigami.Units.largeSpacing
             title: i18nc("@title:group", "Current")
+            visible: (Tailscale.exitNodeModel.rowCount() > 0) || (Tailscale.mullvadNodeModel.rowCount() > 0)
         }
 
         FormCard.FormCard {

--- a/src/ui/ExitNodes.qml
+++ b/src/ui/ExitNodes.qml
@@ -36,6 +36,7 @@ Kirigami.ScrollablePage {
 
         FormCard.FormCard {
             Layout.fillWidth: true
+            visible: (Tailscale.exitNodeModel.rowCount() > 0) || (Tailscale.mullvadNodeModel.rowCount() > 0)
 
             ColumnLayout {
                 spacing: 0

--- a/src/ui/ExitNodes.qml
+++ b/src/ui/ExitNodes.qml
@@ -95,10 +95,12 @@ Kirigami.ScrollablePage {
             Layout.fillWidth: true
             Layout.topMargin: Kirigami.Units.largeSpacing
             title: i18nc("@title:group", "Mullvad")
+            visible: Tailscale.mullvadNodeModel.rowCount() > 0
         }
 
         FormCard.FormCard {
             Layout.fillWidth: true
+            visible: Tailscale.mullvadNodeModel.rowCount() > 0
 
             ColumnLayout {
                 spacing: 0


### PR DESCRIPTION
Fixes #301 and generally hides the exit node menus/actions if none are available.