### PR TITLE
add toggle LAN access to settings

### DIFF
--- a/src/config/preferences.cpp
+++ b/src/config/preferences.cpp
@@ -24,6 +24,13 @@ void Preferences::refresh()
         }
     }
 
+    if (tailscale_get_exit_node_allow_lan_access(&tmpBool) != 0U) {
+        if (static_cast<bool>(tmpBool) != mExitNodeAllowLANAccess) {
+            mExitNodeAllowLANAccess = (tmpBool != 0U);
+            emit allowLANAccessChanged(mExitNodeAllowLANAccess);
+        }
+    }
+
     if (tailscale_get_accept_dns(&tmpBool) != 0U) {
         if (static_cast<bool>(tmpBool) != mAcceptDNS) {
             mAcceptDNS = (tmpBool != 0U);
@@ -88,6 +95,10 @@ bool Preferences::acceptDNS() const
 {
     return mAcceptDNS;
 }
+bool Preferences::allowLANAccess() const
+{
+    return mExitNodeAllowLANAccess;
+}
 bool Preferences::advertiseExitNode() const
 {
     return mAdvertiseExitNode;
@@ -119,6 +130,14 @@ void Preferences::setAcceptRoutes(bool acceptRoutes)
     if (tailscale_set_accept_routes(&tmp) != 0U) {
         mAcceptRoutes = acceptRoutes;
         emit acceptRoutesChanged(mAcceptRoutes);
+    }
+}
+void Preferences::setExitNodeAllowLANAccess(bool allowLANAccess)
+{
+    auto tmp = static_cast<GoUint8>(allowLANAccess);
+    if (tailscale_set_exit_node_allow_lan_access(&tmp) != 0U) {
+        mExitNodeAllowLANAccess = allowLANAccess;
+        emit allowLANAccessChanged(mExitNodeAllowLANAccess);
     }
 }
 void Preferences::setAcceptDNS(bool acceptDNS)

--- a/src/config/preferences.hpp
+++ b/src/config/preferences.hpp
@@ -10,6 +10,7 @@ class Preferences : public QObject
     Q_OBJECT
     Q_PROPERTY(bool acceptRoutes READ acceptRoutes WRITE setAcceptRoutes NOTIFY acceptRoutesChanged)
     Q_PROPERTY(bool acceptDNS READ acceptDNS WRITE setAcceptDNS NOTIFY acceptDNSChanged)
+    Q_PROPERTY(bool allowLANAccess READ allowLANAccess WRITE setExitNodeAllowLANAccess NOTIFY allowLANAccessChanged)
     Q_PROPERTY(bool advertiseExitNode READ advertiseExitNode WRITE setAdvertiseExitNode NOTIFY advertiseExitNodeChanged)
     Q_PROPERTY(QString hostname READ hostname WRITE setHostname NOTIFY hostnameChanged)
     Q_PROPERTY(QString operatorUser READ operatorUser WRITE setOperatorUser NOTIFY operatorUserChanged)
@@ -27,11 +28,13 @@ private:
     bool mShieldsUp{};
     bool mSSH{};
     bool mWebClient{};
+    bool mExitNodeAllowLANAccess{};
 
     explicit Preferences(QObject *parent = nullptr);
 
 signals:
     void acceptRoutesChanged(bool);
+    void allowLANAccessChanged(bool);
     void acceptDNSChanged(bool);
     void advertiseExitNodeChanged(bool);
     void hostnameChanged(const QString &);
@@ -48,6 +51,7 @@ public:
 
     bool acceptRoutes() const;
     bool acceptDNS() const;
+    bool allowLANAccess() const;
     bool advertiseExitNode() const;
     const QString &hostname() const;
     const QString &operatorUser() const;
@@ -56,6 +60,7 @@ public:
     bool webClient() const;
 
     void setAcceptRoutes(bool acceptRoutes);
+    void setExitNodeAllowLANAccess(bool allowLANAccess);
     void setAcceptDNS(bool acceptDNS);
     void setAdvertiseExitNode(bool advertiseExitNode);
     void setHostname(const QString &hostname);

--- a/src/ui/Settings.qml
+++ b/src/ui/Settings.qml
@@ -160,6 +160,16 @@ Kirigami.ScrollablePage {
                 }
 
                 FormCard.FormSwitchDelegate {
+                    id: enableExitNodeLanAccess
+
+                    checked: Preferences.allowLANAccess
+                    enabled: Tailscale.isOperator && Tailscale.success
+                    text: i18nc("@label", "Allow LAN Access:")
+
+                    onClicked: Preferences.allowLANAccess = !Preferences.allowLANAccess
+                }
+
+                FormCard.FormSwitchDelegate {
                     id: acceptRoutes
 
                     checked: Preferences.acceptRoutes

--- a/src/wrapper/options.go
+++ b/src/wrapper/options.go
@@ -54,6 +54,29 @@ func tailscale_set_accept_routes(accept_routes *bool) bool {
 	return true
 }
 
+//export tailscale_get_exit_node_allow_lan_access
+func tailscale_get_exit_node_allow_lan_access(allow_lan_access *bool) bool {
+	curPrefs, err := client.GetPrefs(context.Background())
+	if err != nil {
+		log_critical(fmt.Sprintf("failed to get tailscale preferences: %v", err))
+		return false
+	}
+	*allow_lan_access = curPrefs.ExitNodeAllowLANAccess
+	return true
+}
+
+//export tailscale_set_exit_node_allow_lan_access
+func tailscale_set_exit_node_allow_lan_access(allow_lan_access *bool) bool {
+	args := []string{"set", "--exit-node-allow-lan-access=" + strconv.FormatBool(*allow_lan_access)}
+	err := cli.Run(args)
+	if err != nil {
+		log_critical(fmt.Sprintf("failed to set allow LAN access: %v", err))
+		return false
+	}
+	log_info(fmt.Sprintf("set allow LAN access to %v", *allow_lan_access))
+	return true
+}
+
 //export tailscale_get_advertise_exit_node
 func tailscale_get_advertise_exit_node(exit_node *bool) bool {
 	curPrefs, err := client.GetPrefs(context.Background())


### PR DESCRIPTION
This should get #317 most of the way there

One issue I noticed while testing this was that the toggle only changed the state of exit-node-allow-lan-access once per application launch. 
After this you could no longer change the state of that boolean, even if the FormSwitchDelegate reflected that you'd clicked the toggle.