### PR TITLE
fix: don't use ssh for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "flathub"]
 	path = flathub
-	url = git@github.com:flathub/org.fkoehler.KTailctl.git
+	url = https://github.com/flathub/org.fkoehler.KTailctl.git


### PR DESCRIPTION
this blows up the flatpak build process now
https://github.com/flathub-infra/vorarbeiter/actions/runs/14511204139/job/40710177021#step:8:138

