### PR TITLE
[Bug] Use correct indices when peer model shrinks

### DIFF
--- a/src/peer_model.cpp
+++ b/src/peer_model.cpp
@@ -95,7 +95,7 @@ const QVector<PeerData> &PeerModel::peers() const
 void PeerModel::update(const QVector<PeerData> &peers)
 {
     if (mPeers.size() > peers.size()) {
-        beginRemoveRows(QModelIndex(), 0, mPeers.size() - 1);
+        beginRemoveRows(QModelIndex(), peers.size(), mPeers.size() - 1);
         mPeers.erase(mPeers.begin() + peers.size(), mPeers.end());
         endRemoveRows();
     }


### PR DESCRIPTION
Just saw this incorrect index. This is likely also the cause for https://github.com/f-koehler/KTailctl/issues/391 but I will have to test it.