### PR TITLE
feat(freedesktop): add interface for org.freedesktop.Settings to listen for color-scheme changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ ecm_setup_version(${PROJECT_VERSION} VARIABLE_PREFIX KTAILCTL VERSION_HEADER
 find_package(
   Qt6 ${QT6_MIN_VERSION} REQUIRED
   COMPONENTS Core
+             DBus
              Gui
              # Qml
              Quick

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,11 +6,14 @@ check_ipo_supported(RESULT ipo_supported OUTPUT ipo_output)
 add_subdirectory(ui/components)
 add_subdirectory(wrapper)
 
+qt6_add_dbus_interfaces(KTAILCTL_DBUS_SRCS org.freedesktop.portal.Settings.xml)
+
 add_executable(
   ktailctl
   about.cpp
   app.cpp
   exit_node_model.cpp
+  freedesktop_settings_portal.cpp
   json.cpp
   logging.cpp
   main.cpp
@@ -26,7 +29,8 @@ add_executable(
   taildrop_sender.cpp
   tailscale.cpp
   tray_icon.cpp
-  util.cpp)
+  util.cpp
+  ${KTAILCTL_DBUS_SRCS})
 
 ecm_add_qml_module(ktailctl URI org.fkoehler.KTailctl GENERATE_PLUGIN_SOURCE)
 ecm_target_qml_sources(
@@ -123,6 +127,8 @@ target_link_libraries(
           KF6::CoreAddons
           KF6::WindowSystem
           KF6::GuiAddons
+          Qt6::Core
+          Qt6::DBus
           Qt6::Widgets
           Qt6::Quick
           Qt6::QuickControls2

--- a/src/freedesktop_settings_portal.cpp
+++ b/src/freedesktop_settings_portal.cpp
@@ -1,0 +1,59 @@
+#include "freedesktop_settings_portal.hpp"
+
+FreedesktopSettingsPortal::FreedesktopSettingsPortal(QObject *parent)
+    : QObject(parent)
+    , mConnection(QDBusConnection::sessionBus())
+{
+    mSettingsInterface = new org::freedesktop::portal::Settings(QStringLiteral("org.freedesktop.portal.Settings"), "/", mConnection, this);
+
+    // register for color scheme changes
+    connect(mSettingsInterface,
+            &org::freedesktop::portal::Settings::SettingChanged,
+            this,
+            [this](const QString &ns, const QString &key, const QDBusVariant &value) {
+                if (ns == QStringLiteral("org.freedesktop.appearance") && key == QStringLiteral("color-scheme")) {
+                    updateColorScheme(value);
+                }
+            });
+
+    // get initial value for color scheme setting
+    auto request = mSettingsInterface->ReadOne("org.freedesktop.appearance", "color-scheme");
+    request.waitForFinished();
+    updateColorScheme(request.value());
+    emit colorSchemeChanged(mColorScheme);
+}
+
+void FreedesktopSettingsPortal::updateColorScheme(const QDBusVariant &value)
+{
+    ColorScheme newColorScheme;
+    const int colorSchemeValue = value.variant().toInt();
+    switch (colorSchemeValue) {
+    case 0:
+        newColorScheme = ColorScheme::NoPreference;
+        break;
+    case 1:
+        newColorScheme = ColorScheme::Dark;
+        break;
+    case 2:
+        newColorScheme = ColorScheme::Light;
+        break;
+    default:
+        newColorScheme = ColorScheme::NoPreference;
+        qCritical() << "Unknown color scheme:" << colorSchemeValue;
+    }
+    if (newColorScheme != mColorScheme) {
+        mColorScheme = newColorScheme;
+        emit colorSchemeChanged(mColorScheme);
+    }
+}
+
+FreedesktopSettingsPortal *FreedesktopSettingsPortal::instance()
+{
+    static FreedesktopSettingsPortal instance;
+    return &instance;
+}
+
+FreedesktopSettingsPortal::ColorScheme FreedesktopSettingsPortal::colorScheme() const
+{
+    return mColorScheme;
+}

--- a/src/freedesktop_settings_portal.hpp
+++ b/src/freedesktop_settings_portal.hpp
@@ -1,0 +1,39 @@
+#ifndef KTAILCTL_SRC_SETTINGS_PORTAL_HPP
+#define KTAILCTL_SRC_SETTINGS_PORTAL_HPP
+
+#include "settingsinterface.h"
+#include <QDBusConnection>
+#include <QObject>
+
+class FreedesktopSettingsPortal : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(ColorScheme colorScheme READ colorScheme NOTIFY colorSchemeChanged)
+
+public:
+    enum class ColorScheme : int {
+        NoPreference = 0,
+        Dark = 1,
+        Light = 2,
+    };
+    Q_ENUM(ColorScheme)
+
+private:
+    QDBusConnection mConnection;
+    org::freedesktop::portal::Settings *mSettingsInterface;
+    ColorScheme mColorScheme = ColorScheme::NoPreference;
+
+    explicit FreedesktopSettingsPortal(QObject *parent = nullptr);
+
+    void updateColorScheme(const QDBusVariant &value);
+
+public:
+    static FreedesktopSettingsPortal *instance();
+
+    ColorScheme colorScheme() const;
+
+signals:
+    void colorSchemeChanged(ColorScheme value);
+};
+
+#endif /* KTAILCTL_SRC_SETTINGS_PORTAL_HPP */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 
 #include "about.hpp"
 #include "app.hpp"
+#include "freedesktop_settings_portal.hpp"
 #include "logging.hpp"
 #include "peer_model.hpp"
 #include "preferences.hpp"
@@ -91,6 +92,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     qmlRegisterSingletonInstance("org.fkoehler.KTailctl", 1, 0, "App", application);
     qmlRegisterSingletonInstance("org.fkoehler.KTailctl", 1, 0, "Util", util);
     qmlRegisterSingletonInstance("org.fkoehler.KTailctl", 1, 0, "TaildropSendJobFactory", TaildropSendJobFactory::instance());
+    qmlRegisterSingletonInstance("org.fkoehler.KTailctl", 1, 0, "FreedesktopSettingsPortal", FreedesktopSettingsPortal::instance());
 
     qmlRegisterType<SpeedStatistics>("org.fkoehler.KTailctl", 1, 0, "SpeedStatistics");
     qmlRegisterType<Statistics>("org.fkoehler.KTailctl", 1, 0, "Statistics");

--- a/src/org.freedesktop.portal.Settings.xml
+++ b/src/org.freedesktop.portal.Settings.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2018 Igalia S.L.
+
+ SPDX-License-Identifier: LGPL-2.1-or-later
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+ Author: Patrick Griffis <pgriffis@igalia.com>
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+    org.freedesktop.portal.Settings:
+    @short_description: Settings interface
+
+    This interface provides read-only access to a small number of standardized
+    host settings required for toolkits similar to XSettings. It is not for
+    general purpose settings.
+
+    Implementations can provide keys not listed below; they are entirely
+    implementation details that are undocumented. If you are a toolkit and want
+    to use this please open an issue.
+
+    Currently the interface provides the following standardized keys:
+
+    * ``org.freedesktop.appearance`` ``color-scheme`` (``u``)
+
+      Indicates the system's preferred color scheme.
+      Supported values are:
+
+        * ``0``: No preference
+        * ``1``: Prefer dark appearance
+        * ``2``: Prefer light appearance
+
+      Unknown values should be treated as ``0`` (no preference).
+
+    * ``org.freedesktop.appearance`` ``accent-color`` (``(ddd)``)
+
+      Indicates the system's preferred accent color as a tuple of RGB values in
+      the sRGB color space, in the range [0,1]. Out-of-range RGB values should
+      be treated as an unset accent color.
+
+    * ``org.freedesktop.appearance``  ``contrast`` (``u``)
+
+      Indicates the system's preferred contrast level.
+      Supported values are:
+
+        * ``0``: No preference (normal contrast)
+        * ``1``: Higher contrast
+
+      Unknown values should be treated as ``0`` (no preference).
+
+    This documentation describes version 2 of this interface.
+  -->
+  <interface name="org.freedesktop.portal.Settings">
+
+    <!--
+      ReadAll:
+      @namespaces: List of namespaces to filter results by, supports simple globbing explained below.
+      @value: Dictionary of namespaces to its keys and values.
+
+      If @namespaces is an empty array or contains an empty string it matches all. Globbing is supported
+    but only for
+      trailing sections, e.g. "org.example.*".
+    -->
+    <method name="ReadAll">
+      <arg type="as" name="namespaces" direction="in" />
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0"
+        value="QMap&lt;QString,QVariantMap&gt;" />
+      <arg type="a{sa{sv}}" name="value" direction="out" />
+    </method>
+
+    <!--
+      Read:
+      @ns: Namespace to look up @key in.
+      @key: The key to get.
+      @value: The value @key is set to.
+
+      Reads a single value. Returns an error on any unknown namespace or key.
+
+      Deprecated, use ReadOne instead. The value argument was intended to have
+      the value inside one layer of variant as it is in ReadOne, for example
+      `&lt;string "hello"&gt;` in GVariant text notation; but it is actually
+      returned inside two layers of variant, for example
+      `&lt;&lt;string "hello"&gt;&gt;`.
+    -->
+    <method name="Read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true" />
+      <arg type="s" name="ns" direction="in" />
+      <arg type="s" name="key" direction="in" />
+      <arg type="v" name="value" direction="out" />
+    </method>
+
+    <!--
+      ReadOne:
+      @ns: Namespace to look up @key in.
+      @key: The key to get.
+      @value: The value @key is set to.
+
+      Reads a single value which may be any valid DBus type. Returns an error on any unknown namespace or
+    key.
+
+      This method was added in version 2.
+    -->
+    <method name="ReadOne">
+      <arg type="s" name="ns" direction="in" />
+      <arg type="s" name="key" direction="in" />
+      <arg type="v" name="value" direction="out" />
+    </method>
+
+    <!--
+      SettingChanged:
+      @ns: Namespace of changed setting.
+      @key: The key of changed setting.
+      @value: The new value.
+
+      Emitted when a setting changes.
+    -->
+    <signal name="SettingChanged">
+      <arg type="s" name="ns" direction="out" />
+      <arg type="s" name="key" direction="out" />
+      <arg type="v" name="value" direction="out" />
+    </signal>
+
+    <property name="version" type="u" access="read" />
+  </interface>
+</node>

--- a/src/themes.hpp
+++ b/src/themes.hpp
@@ -6,12 +6,15 @@
 
 static const QStringList TrayIconThemes = {QStringLiteral("breeze-light"),
                                            QStringLiteral("breeze-dark"),
+                                           QStringLiteral("breeze-auto"),
                                            QStringLiteral("colorful"),
                                            QStringLiteral("adwaita-dark"),
                                            QStringLiteral("adwaita-light"),
+                                           QStringLiteral("adwaita-auto"),
                                            QStringLiteral("catppuccin-latte"),
                                            QStringLiteral("catppuccin-frappe"),
                                            QStringLiteral("catppuccin-macchiato"),
-                                           QStringLiteral("catppuccin-mocha")};
+                                           QStringLiteral("catppuccin-mocha"),
+                                           QStringLiteral("catppuccin-auto")};
 
 #endif /* KTAILCTL_GENERATE_ICONS_PY */


### PR DESCRIPTION
Fixes #401

So far an interface for DBus has been implemented that listens to changes for the freedesktop color-scheme preference. Next step is to actually change the tray icon.