### PR TITLE
Fix memory leak and stale UI bug in MullvadCountryModel (closes #481)

### DIFF
--- a/src/mullvad_country_model.cpp
+++ b/src/mullvad_country_model.cpp
@@ -32,15 +32,19 @@ QVariant MullvadCountryModel::data(const QModelIndex &index, int role) const
 
 void MullvadCountryModel::update(const QMap<QString, QString> &countries)
 {
-    if (countries.size() == mCountries.size()) {
-        return;
-    }
-    beginResetModel();
+    QList<QPair<QString, QString>> newCountries;
     for (auto it = countries.cbegin(); it != countries.cend(); ++it) {
         if (it->isEmpty()) {
             continue;
         }
-        mCountries.append({it.key(), it.value()});
+        newCountries.append({it.key(), it.value()});
     }
+
+    if (newCountries == mCountries) {
+        return;
+    }
+
+    beginResetModel();
+    mCountries = newCountries;
     endResetModel();
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
 enable_testing()
-# add_executable(test_data test_data.cpp) target_link_libraries(test_data Qt6::Test KTailctl::Data KTailctl::Tailscale)
-# add_test(NAME test_data COMMAND test_data)
+add_executable(test_mullvad_country_model test_mullvad_country_model.cpp)
+target_link_libraries(test_mullvad_country_model Qt6::Test KTailctl::Data KTailctl::Tailscale)
+add_test(NAME test_mullvad_country_model COMMAND test_mullvad_country_model)

--- a/tests/test_mullvad_country_model.cpp
+++ b/tests/test_mullvad_country_model.cpp
@@ -1,0 +1,46 @@
+#include "mullvad_country_model.hpp"
+#include <QTest>
+#include <QMap>
+#include <QString>
+
+class TestMullvadCountryModel : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testUnboundedGrowth()
+    {
+        MullvadCountryModel model;
+        
+        QMap<QString, QString> countries40;
+        for (int i = 0; i < 40; ++i) {
+            countries40.insert(QString::number(i), QStringLiteral("Country ") + QString::number(i));
+        }
+
+        QMap<QString, QString> countries41 = countries40;
+        countries41.insert(QStringLiteral("40"), QStringLiteral("Country 40"));
+
+        QMap<QString, QString> countries39 = countries40;
+        countries39.remove(QStringLiteral("39"));
+
+        // Initial setup
+        model.update(countries40);
+        QCOMPARE(model.rowCount(), 40);
+
+        // Simulate fluctuating node counts during regular refresh cycles
+        // Unpatched code will grow geometrically with every call
+        for (int i = 0; i < 300; ++i) {
+            model.update(countries41);
+            QCOMPARE(model.rowCount(), 41);
+            
+            model.update(countries39);
+            QCOMPARE(model.rowCount(), 39);
+
+            model.update(countries40);
+            QCOMPARE(model.rowCount(), 40);
+        }
+    }
+};
+
+QTEST_MAIN(TestMullvadCountryModel)
+#include "test_mullvad_country_model.moc"


### PR DESCRIPTION
Fix memory leak and stale UI bug in MullvadCountryModel

Resolves #481.

The MullvadCountryModel::update() method appended new items during the beginResetModel() block but omitted mCountries.clear(). Because Tailscale::refreshStatus() fires on a 1Hz timer, any fluctuation in the Mullvad node count (where countries.size() != mCountries.size()) triggered an unbounded geometric explosion of the underlying model array. This caused massive QML tracking overhead and OOM crashes over prolonged sessions.

Bonus: The previous size-based early-return also missed updates where one country went offline and another came online (same size, different data). The operator== comparison correctly detects this data mutation and triggers the model reset, preventing the UI from growing stale.

Changes:

Swapped the fragile length-check optimization for a deterministic operator== exact comparison.
Bounded array reassignment using mCountries = newCountries to safely overwrite and free old entries.
Added the test_mullvad_country_model pure C++ standalone regression test to verify monotonic growth is eliminated under a fluctuating data stream.